### PR TITLE
Add support for CDATA nodes

### DIFF
--- a/lib/xmlrpc_lib.js
+++ b/lib/xmlrpc_lib.js
@@ -2492,10 +2492,11 @@ function getSingleChild(node, expectedType)
 function getChildText(node)
 {
 	var ret = '';
+	var child;
 	for(var i = 0; i < node.childNodes.length; i++)
 	{
 		child = node.childNodes.item(i);
-		if (child.nodeType == 3) // ignore comments (8), character data (3), ...
+		if (child.nodeType == 3 || child.nodeType == 4) // handle text and cdata, ignore comments (8), ...
 		{
 			ret += String(child.nodeValue)
 		}


### PR DESCRIPTION
This code used to fail to work (it was returning empty `url`):

```
<?xml version="1.0"?>
<methodResponse>
<params>
<param><value><struct>
<member><name>task_id</name>
<value><string>56b539723cac6e76b64bc490</string></value></member>
<member><name>item_id</name>
<value><string>29782764-938a-45a7-a766-4f71b18791d9</string></value></member>
<member><name>url</name>
<value><string><![CDATA[https://example.com:1001/script.blah?date=2016-02-04-T12.36.19-tracks.td&id=40386975&ts=1]]></string></value></member>
</struct></value></param></params></methodResponse>
```

Now it's returning url: `https://example.com:1001/script.blah?date=2016-02-04-T12.36.19-tracks.td&id=40386975&ts=1`
