### PR TITLE
Handle <undefined>undefined</undefined> in server response

### DIFF
--- a/lib/xmlrpc_lib.js
+++ b/lib/xmlrpc_lib.js
@@ -876,6 +876,9 @@ xmlrpcval.prototype.init = function (val, type) {
 				this.mytype = 3;
 				this.myidx = 0;
 				break;
+      case 'undefined':
+				this.mytype = 9;
+				break;
 			default:
 				xmlrpc_error_log('XML-RPC: xmlrpcval::xmlrpcval: not a known type ('+type+')');
 		}
@@ -2657,6 +2660,14 @@ function parseXmlrpcValue(node, return_jsvals)
                         break;
                     }
                     // fall through voluntarily
+                    
+				case 'undefined':
+					var text = getChildText(child);
+					if (text != 'undefined') {
+						console.log("Warning: <undefined> tag contained value: " + text + " (expected: string \"undefined\")");
+					}
+					ret = null;
+					break;
 				default:
 					throw 'Found incorrect element inside \'value\' :'+ child.tagName;
 


### PR DESCRIPTION
Sample server response which was not handled before this fix:

```
<?xml version="1.0"?>
<methodResponse>
<params>
<param>
<value><struct>
<member>
<name>task_id</name>
<value><string>56c66c8afbc8c16bd18641c6</string></value>
</member>
<member>
<name>answer_id</name>
<value><string>0a32d8d0-a2bc-42bd-8599-6764c31ff775</string></value>
</member>
<member>
<name>url</name>
<value><undefined>undefined</undefined></value>
</member>
</struct>
</value>
</param>
</params>
</methodResponse>
```
